### PR TITLE
Add command line option to set metric server address

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ OPTIONS:
 -pprof.addr <ip:port>
     pprof server address. pprof will expose it's metrics on this address.
   
+-metric.addr <ip:port>
+    metric server address. prometheus metrics will be exposed on this address.
+    Default: *:2112
+
 -log.lvl {trace,debug,info,warn,error,fatal}
     Log level.
     Default: info

--- a/main.go
+++ b/main.go
@@ -29,9 +29,10 @@ func main() {
 }
 
 func run(args []string, stdout io.Writer) error {
-	var confFile, pprofAddr, loglvl string
+	var confFile, pprofAddr, metricAddr, loglvl string
 	flag.StringVar(&confFile, "config", "config.yaml", "path to config file")
 	flag.StringVar(&pprofAddr, "pprof.addr", "", "pprof addr")
+	flag.StringVar(&metricAddr, "metric.addr", ":2112", "metric server addr")
 	flag.StringVar(&loglvl, "log.lvl", "debug", "log level. Can be {trace,debug,info,warn,error,fatal}")
 	flag.Parse()
 
@@ -67,7 +68,7 @@ func run(args []string, stdout io.Writer) error {
 	}
 
 	// Create metrics server
-	scanner.MetricsServ = *metrics.Init()
+	scanner.MetricsServ = *metrics.Init(metricAddr)
 
 	// Start metrics server
 	go func() {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -38,7 +38,7 @@ type PingInfo struct {
 }
 
 // Init initialize the metrics
-func Init() *Server {
+func Init(addr string) *Server {
 	s := Server{
 		NumOfTargets: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "scanexporter_targets_number_total",
@@ -96,6 +96,8 @@ func Init() *Server {
 		s.Rtt,
 	)
 
+	s.Addr = addr
+
 	// Initialize the map
 	s.NotRespondingList = make(map[string]bool)
 
@@ -108,7 +110,7 @@ func Init() *Server {
 // Start starts the prometheus server
 func (s *Server) Start() error {
 	srv := &http.Server{
-		Addr:         ":2112",
+		Addr:         s.Addr,
 		Handler:      handlers.HandleFunc(),
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,


### PR DESCRIPTION
This is a simple change to allow the metric server listen address to be specified on the command line.