### PR TITLE
chore: fix goreleaser version

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
-          args: release --rm-dist
+          version: v1.8.2
+          args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -26,6 +26,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: v1.8.2
-          args: release
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes the Goreleaser version to the one used during last successful build (merge of #12), so we can have a working (and iso) release flow for now, and making faa096d green.

Then it should be bumped to the latest fixed release in #14 