### PR TITLE
feat: create codeowners to enable branch protection

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,1 @@
+* @devops-works/admins @eze-kiel


### PR DESCRIPTION
This PR creates a CODEOWNER file so we can enforce branch protection and enforce at least one mandatory review from a codeowner of the repo.