### PR TITLE
Replace for-select with for-range

### DIFF
--- a/scan/icmp.go
+++ b/scan/icmp.go
@@ -25,47 +25,44 @@ func (t *target) ping(logger zerolog.Logger, timeout time.Duration, pchan chan m
 
 	ticker := time.NewTicker(randPeriod)
 
-	for {
-		select {
-		case <-ticker.C:
-			pinfo := metrics.PingInfo{
-				Name:         t.name,
-				IP:           t.ip,
-				IsResponding: false,
-				RTT:          0,
-			}
+	for range ticker.C {
+		pinfo := metrics.PingInfo{
+			Name:         t.name,
+			IP:           t.ip,
+			IsResponding: false,
+			RTT:          0,
+		}
 
-			pinger, err := ping.NewPinger(t.ip)
-			if err != nil {
-				logger.Error().Err(err).Msgf("error creating pinger for %s (%s)", t.name, t.ip)
-				continue
-			}
+		pinger, err := ping.NewPinger(t.ip)
+		if err != nil {
+			logger.Error().Err(err).Msgf("error creating pinger for %s (%s)", t.name, t.ip)
+			continue
+		}
 
-			pinger.Timeout = timeout
-			pinger.SetPrivileged(true)
-			pinger.Count = 3
+		pinger.Timeout = timeout
+		pinger.SetPrivileged(true)
+		pinger.Count = 3
 
-			pinger.OnFinish = func(stats *ping.Statistics) {
-				logger.Debug().Str("name", t.name).Str("ip", t.ip).Msgf("ping ended")
-				pinfo.RTT = stats.AvgRtt
-				if stats.AvgRtt != 0 {
-					pinfo.IsResponding = true
-				} else {
-					pinfo.IsResponding = false
-				}
-				pchan <- pinfo
+		pinger.OnFinish = func(stats *ping.Statistics) {
+			logger.Debug().Str("name", t.name).Str("ip", t.ip).Msgf("ping ended")
+			pinfo.RTT = stats.AvgRtt
+			if stats.AvgRtt != 0 {
+				pinfo.IsResponding = true
+			} else {
+				pinfo.IsResponding = false
 			}
+			pchan <- pinfo
+		}
 
-			pinger.OnRecv = func(p *ping.Packet) {
-				logger.Debug().Str("name", t.name).Str("ip", t.ip).Msgf("received one ICMP reply")
-			}
+		pinger.OnRecv = func(p *ping.Packet) {
+			logger.Debug().Str("name", t.name).Str("ip", t.ip).Msgf("received one ICMP reply")
+		}
 
-			logger.Debug().Str("name", t.name).Str("ip", t.ip).Msgf("running a new ping")
-			err = pinger.Run()
-			if err != nil {
-				logger.Error().Err(err).Msgf("error running pinger for %s (%s)", t.name, t.ip)
-				continue
-			}
+		logger.Debug().Str("name", t.name).Str("ip", t.ip).Msgf("running a new ping")
+		err = pinger.Run()
+		if err != nil {
+			logger.Error().Err(err).Msgf("error running pinger for %s (%s)", t.name, t.ip)
+			continue
 		}
 	}
 }


### PR DESCRIPTION
Replaced the `for { select { } }` pattern with `for range` for both the `ticker.C` and `trigger` channels.

This resolves the warning about using `for { select {} }` and makes the code more idiomatic by using `for-range`, which is preferred when working with channels.