### PR TITLE
Bump golang 1.24.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM devopsworks/golang-upx:1.24.2 AS builder
+FROM devopsworks/golang-upx:1.24.4 AS builder
 
 RUN apt-get update && apt-get install -y libcap2-bin
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devops-works/scan-exporter
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/go-ping/ping v1.2.0


### PR DESCRIPTION
Should be merged after https://github.com/devops-works/docker-golang-upx/pull/6 is merged.