### PR TITLE
Improve port parsing to support combined specifications

### DIFF
--- a/scan/utils_test.go
+++ b/scan/utils_test.go
@@ -34,6 +34,16 @@ func Test_getDuration(t *testing.T) {
 }
 
 func Test_readPortsRange(t *testing.T) {
+	reservedPorts := make([]int, 1023)
+	for i := range 1023 {
+		reservedPorts[i] = i + 1
+	}
+
+	allPorts := make([]int, 65535)
+	for i := range 65535 {
+		allPorts[i] = i + 1
+	}
+
 	tests := []struct {
 		name    string
 		ranges  string
@@ -45,7 +55,29 @@ func Test_readPortsRange(t *testing.T) {
 		{name: "hyphen", ranges: "22-25", want: []int{22, 23, 24, 25}, wantErr: false},
 		{name: "comma and hyphen", ranges: "22,30-32", want: []int{22, 30, 31, 32}, wantErr: false},
 		{name: "comma, hyphen, comma", ranges: "22,30-32,50", want: []int{22, 30, 31, 32, 50}, wantErr: false},
-		{name: "unknown", ranges: "foobar", wantErr: true},
+
+		// Tests for keywords
+		{name: "keyword all", ranges: "all", want: allPorts, wantErr: false},
+		{name: "keyword reserved", ranges: "reserved", want: reservedPorts, wantErr: false},
+		{name: "keyword top1000", ranges: "top1000", want: top1000Ports, wantErr: false},
+
+		// Tests for combinations and uniqueness
+		{name: "duplicates", ranges: "80,81,443,79-88", want: []int{79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 443}, wantErr: false},
+		{name: "reserved with duplicates", ranges: "1,2,reserved", want: reservedPorts, wantErr: false},
+		{name: "all with others", ranges: "80,all,9000", want: allPorts, wantErr: false},
+
+		// Tests for edge cases
+		{name: "empty string", ranges: "", want: []int{}, wantErr: false},
+		{name: "whitespace and commas", ranges: " , ", want: []int{}, wantErr: false},
+
+		// Tests for error conditions
+		{name: "unknown keyword", ranges: "foobar", wantErr: true},
+		{name: "invalid range min > max", ranges: "100-20", wantErr: true},
+		{name: "port > 65535", ranges: "65536", wantErr: true},
+		{name: "port < 1", ranges: "0", wantErr: true},
+		{name: "range end > 65535", ranges: "65530-65536", wantErr: true},
+		{name: "malformed range end", ranges: "100-", wantErr: true},
+		{name: "malformed range start", ranges: "-100", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The `readPortsRange` function was previously limited to a single keyword or range per call, making it difficult for users to define complex port sets. For instance, scanning the top 1000 ports **and** a specific custom port required extra logic outside the function.

This commit refactors the function to parse a comma-separated string containing multiple specifications. It now supports combining keywords (`top1000`, `reserved`), single ports, and ranges in one input, like `"top1000,8080,9000-9100"`.

The final list of ports is de-duplicated and sorted to ensure a clean, predictable output.