### PR TITLE
Bump golang 1.24.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM devopsworks/golang-upx:1.24.5 AS builder
+FROM devopsworks/golang-upx:1.24.6 AS builder
 
 RUN apt-get update && apt-get install -y libcap2-bin
 


### PR DESCRIPTION
https://github.com/devops-works/docker-golang-upx/pull/8 has already been merged thanks to @guoard.