### PR TITLE
Bump go.mod 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devops-works/scan-exporter
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/go-ping/ping v1.2.0


### PR DESCRIPTION
Sorry, I forgot this in https://github.com/devops-works/scan-exporter/pull/24.